### PR TITLE
Update README to use yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ To get started with tinkering with the site locally, clone the repo down, instal
 
 ```sh
 git clone https://github.com/lannonbr/LC-Heatmap.git
-npm install
-npm run develop
+yarn
+yarn run develop
 ```
 
 This will run `parcel` as a HMR server so whenever you make changes to the various files, the bundle will rebuild and refresh the page live.


### PR DESCRIPTION
Noticed that in the repository you have a `yarn.lock` file and thought it might be good to align on the tool in case, you get contributors using npm and they produce a `package-lock.json`