### PR TITLE
Updates sidebar to be hidden from DOM until revealed

### DIFF
--- a/site/js/genHeatmap.js
+++ b/site/js/genHeatmap.js
@@ -80,6 +80,7 @@ export function generateHeatmap(data) {
     .append("div")
     .attr("class", "card tooltip")
     .style("opacity", 0)
+    .style("display", "none")
 
   //Read the data
   let tiles = svg
@@ -99,7 +100,10 @@ export function generateHeatmap(data) {
     .style("fill", d => myColor(d.value))
     .on("click", d => {
       if (d.streamers.length > 0) {
-        sidebar.transition(250).style("opacity", 1)
+        sidebar
+          .transition(250)
+            .style("opacity", 1)
+            .style("display", "block")
         let html = `
           <button id="sidebarCloseButton" class="rounded shadow">X</button>
           <h2>${d.streamers.length} streamers</h2>
@@ -129,6 +133,12 @@ export function generateHeatmap(data) {
 }
 
 function closeSidebar() {
-  sidebar.transition(250).style("opacity", 0)
+  sidebar
+    .transition(250)
+      .style("opacity", 0)
+    .transition()
+      .delay(250)
+      .style("display", "none")
+
   document.body.className = ""
 }


### PR DESCRIPTION
I noticed when playing around with the site, I couldn't click on the "repo" link. I thought it was because something wasn't wrapped by an `<a>` tag but actually it was because the sidebar was in the way. I believe that `opacity` just hides it "visually" from the user but not from the page:

**Before** 
![image of sidebar `div` blocking repo link](https://user-images.githubusercontent.com/8431042/78284921-174a3880-74ee-11ea-9ecb-3dcb99c52ecd.png)

**After**
![image of sidebar being invisible on the page](https://user-images.githubusercontent.com/8431042/78285042-4bbdf480-74ee-11ea-9dc5-4851a384b02d.png)
